### PR TITLE
fix:  getty session auto close bug

### DIFF
--- a/pkg/common/log/logging.go
+++ b/pkg/common/log/logging.go
@@ -104,7 +104,15 @@ var (
 	log       Logger
 	zapLogger *zap.Logger
 
-	zapLoggerConfig        = zap.NewDevelopmentConfig()
+	zapLoggerConfig = zap.Config{
+		// todo read level from config
+		Level:            zap.NewAtomicLevelAt(zap.InfoLevel),
+		Development:      true,
+		Encoding:         "console",
+		EncoderConfig:    zap.NewDevelopmentEncoderConfig(),
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
+	}
 	zapLoggerEncoderConfig = zapcore.EncoderConfig{
 		TimeKey:        "time",
 		LevelKey:       "level",

--- a/pkg/config/getty_config.go
+++ b/pkg/config/getty_config.go
@@ -38,8 +38,8 @@ type GettyConfig struct {
 // GetDefaultGettyConfig ...
 func GetDefaultGettyConfig() GettyConfig {
 	return GettyConfig{
-		ReconnectInterval: 1,
-		ConnectionNum:     20,
+		ReconnectInterval: 0,
+		ConnectionNum:     1,
 		HeartbeatPeriod:   10 * time.Second,
 		GettySessionParam: GettySessionParam{
 			CompressEncoding: false,
@@ -51,7 +51,7 @@ func GetDefaultGettyConfig() GettyConfig {
 			TCPReadTimeout:   time.Second,
 			TCPWriteTimeout:  5 * time.Second,
 			WaitTimeout:      time.Second,
-			CronPeriod:       5 * time.Second,
+			CronPeriod:       time.Second,
 			MaxMsgLen:        4096,
 			SessionName:      "rpc_client",
 		},

--- a/pkg/protocol/codec/branch_commit_response_codec.go
+++ b/pkg/protocol/codec/branch_commit_response_codec.go
@@ -39,7 +39,7 @@ func (g *BranchCommitResponseCodec) Decode(in []byte) interface{} {
 
 	data.ResultCode = message.ResultCode(bytes.ReadByte(buf))
 	if data.ResultCode == message.ResultCodeFailed {
-		data.Msg = bytes.ReadString16Length(buf)
+		data.Msg = bytes.ReadString8Length(buf)
 	}
 	data.TransactionExceptionCode = serror.TransactionExceptionCode(bytes.ReadByte(buf))
 	data.Xid = bytes.ReadString16Length(buf)
@@ -56,10 +56,10 @@ func (g *BranchCommitResponseCodec) Encode(in interface{}) []byte {
 	buf.WriteByte(byte(data.ResultCode))
 	if data.ResultCode == message.ResultCodeFailed {
 		msg := data.Msg
-		if len(data.Msg) > math.MaxInt16 {
-			msg = data.Msg[:math.MaxInt16]
+		if len(data.Msg) > math.MaxInt8 {
+			msg = data.Msg[:math.MaxInt8]
 		}
-		bytes.WriteString16Length(msg, buf)
+		bytes.WriteString8Length(msg, buf)
 	}
 	buf.WriteByte(byte(data.TransactionExceptionCode))
 	bytes.WriteString16Length(data.Xid, buf)

--- a/pkg/protocol/codec/branch_rollback_response_codec.go
+++ b/pkg/protocol/codec/branch_rollback_response_codec.go
@@ -39,7 +39,7 @@ func (g *BranchRollbackResponseCodec) Decode(in []byte) interface{} {
 
 	data.ResultCode = message.ResultCode(bytes.ReadByte(buf))
 	if data.ResultCode == message.ResultCodeFailed {
-		data.Msg = bytes.ReadString16Length(buf)
+		data.Msg = bytes.ReadString8Length(buf)
 	}
 	data.TransactionExceptionCode = serror.TransactionExceptionCode(bytes.ReadByte(buf))
 	data.Xid = bytes.ReadString16Length(buf)
@@ -59,7 +59,7 @@ func (g *BranchRollbackResponseCodec) Encode(in interface{}) []byte {
 		if len(data.Msg) > math.MaxInt16 {
 			msg = data.Msg[:math.MaxInt16]
 		}
-		bytes.WriteString16Length(msg, buf)
+		bytes.WriteString8Length(msg, buf)
 	}
 	buf.WriteByte(byte(data.TransactionExceptionCode))
 	bytes.WriteString16Length(data.Xid, buf)

--- a/pkg/remoting/getty/listener.go
+++ b/pkg/remoting/getty/listener.go
@@ -24,6 +24,7 @@ import (
 	getty "github.com/apache/dubbo-getty"
 	"github.com/seata/seata-go/pkg/common/log"
 	"github.com/seata/seata-go/pkg/config"
+	"github.com/seata/seata-go/pkg/protocol/codec"
 	"github.com/seata/seata-go/pkg/protocol/message"
 	"github.com/seata/seata-go/pkg/remoting/processor"
 	"go.uber.org/atomic"
@@ -39,7 +40,8 @@ type gettyClientHandler struct {
 	idGenerator    *atomic.Uint32
 	msgFutures     *sync.Map
 	mergeMsgMap    *sync.Map
-	processorTable map[message.MessageType]processor.RemotingProcessor
+	sessionManager *SessionManager
+	processorMap   map[message.MessageType]processor.RemotingProcessor
 }
 
 func GetGettyClientHandlerInstance() *gettyClientHandler {
@@ -50,70 +52,84 @@ func GetGettyClientHandlerInstance() *gettyClientHandler {
 				idGenerator:    &atomic.Uint32{},
 				msgFutures:     &sync.Map{},
 				mergeMsgMap:    &sync.Map{},
-				processorTable: make(map[message.MessageType]processor.RemotingProcessor, 0),
+				sessionManager: sessionManager,
+				processorMap:   make(map[message.MessageType]processor.RemotingProcessor, 0),
 			}
 		})
 	}
 	return clientHandler
 }
 
-func (client *gettyClientHandler) OnOpen(session getty.Session) error {
-	sessionManager.RegisterGettySession(session)
+func (g *gettyClientHandler) OnOpen(session getty.Session) error {
+	log.Infof("Open new getty session ")
+	g.sessionManager.registerSession(session)
 	go func() {
 		request := message.RegisterTMRequest{AbstractIdentifyRequest: message.AbstractIdentifyRequest{
-			Version:                 client.conf.SeataVersion,
-			ApplicationId:           client.conf.ApplicationID,
-			TransactionServiceGroup: client.conf.TransactionServiceGroup,
+			Version:                 g.conf.SeataVersion,
+			ApplicationId:           g.conf.ApplicationID,
+			TransactionServiceGroup: g.conf.TransactionServiceGroup,
 		}}
 		err := GetGettyRemotingClient().SendAsyncRequest(request)
-		//client.sendAsyncRequestWithResponse(session, request, RPC_REQUEST_TIMEOUT)
 		if err != nil {
 			log.Errorf("OnOpen error: {%#v}", err.Error())
-			sessionManager.ReleaseGettySession(session)
+			g.sessionManager.releaseSession(session)
 			return
 		}
-		//todo
-		//client.GettySessionOnOpenChannel <- session.RemoteAddr()
 	}()
+
 	return nil
 }
 
-func (client *gettyClientHandler) OnError(session getty.Session, err error) {
-	log.Infof("OnError session{%s} got error{%v}, will be closed.", session.Stat(), err)
-	sessionManager.ReleaseGettySession(session)
+func (g *gettyClientHandler) OnError(session getty.Session, err error) {
+	log.Infof("session{%s} got error{%v}, will be closed.", session.Stat(), err)
+	g.sessionManager.releaseSession(session)
 }
 
-func (client *gettyClientHandler) OnClose(session getty.Session) {
-	log.Infof("OnClose session{%s} is closing......", session.Stat())
-	sessionManager.ReleaseGettySession(session)
+func (g *gettyClientHandler) OnClose(session getty.Session) {
+	log.Infof("session{%s} is closing......", session.Stat())
+	g.sessionManager.releaseSession(session)
 }
 
-func (client *gettyClientHandler) OnMessage(session getty.Session, pkg interface{}) {
+func (g *gettyClientHandler) OnMessage(session getty.Session, pkg interface{}) {
 	ctx := context.Background()
-	log.Debugf("received message: {%#v}", pkg)
+	log.Debug("received message: {%#v}", pkg)
+
 	rpcMessage, ok := pkg.(message.RpcMessage)
 	if !ok {
 		log.Errorf("received message is not protocol.RpcMessage. pkg: %#v", pkg)
 		return
 	}
+
 	if mm, ok := rpcMessage.Body.(message.MessageTypeAware); ok {
-		processor := client.processorTable[mm.GetTypeCode()]
+		processor := g.processorMap[mm.GetTypeCode()]
 		if processor != nil {
 			processor.Process(ctx, rpcMessage)
 		} else {
-			log.Errorf("This message type [%v] has no processor.", mm.GetTypeCode())
+			log.Errorf("This message type %v has no processor.", mm.GetTypeCode())
 		}
 	} else {
 		log.Errorf("This rpcMessage body %#v is not MessageTypeAware type.", rpcMessage.Body)
 	}
 }
 
-func (client *gettyClientHandler) OnCron(session getty.Session) {
-	//GetGettyRemotingClient().SendAsyncRequest(message.HeartBeatMessagePing)
+func (g *gettyClientHandler) OnCron(session getty.Session) {
+	log.Debug("session{%s} Oncron executing", session.Stat())
+	g.transferBeatHeart(session, message.HeartBeatMessagePing)
 }
 
-func (client *gettyClientHandler) RegisterProcessor(msgType message.MessageType, processor processor.RemotingProcessor) {
+func (g *gettyClientHandler) transferBeatHeart(session getty.Session, msg message.HeartBeatMessage) {
+	rpcMessage := message.RpcMessage{
+		ID:         int32(g.idGenerator.Inc()),
+		Type:       message.GettyRequestType_HeartbeatRequest,
+		Codec:      byte(codec.CodecTypeSeata),
+		Compressor: 0,
+		Body:       msg,
+	}
+	GetGettyRemotingInstance().SendASync(rpcMessage, session, nil)
+}
+
+func (g *gettyClientHandler) RegisterProcessor(msgType message.MessageType, processor processor.RemotingProcessor) {
 	if nil != processor {
-		client.processorTable[msgType] = processor
+		g.processorMap[msgType] = processor
 	}
 }

--- a/pkg/remoting/processor/client/client_heart_beat_processon.go
+++ b/pkg/remoting/processor/client/client_heart_beat_processon.go
@@ -21,20 +21,21 @@ import (
 	"context"
 
 	"github.com/seata/seata-go/pkg/common/log"
+
 	"github.com/seata/seata-go/pkg/protocol/message"
 	"github.com/seata/seata-go/pkg/remoting/getty"
 )
 
 func init() {
-	getty.GetGettyClientHandlerInstance().RegisterProcessor(message.MessageType_HeartbeatMsg, &clientHeartBeatProcesson{})
+	getty.GetGettyClientHandlerInstance().RegisterProcessor(message.MessageType_HeartbeatMsg, &clientHeartBeatProcessor{})
 }
 
-type clientHeartBeatProcesson struct{}
+type clientHeartBeatProcessor struct{}
 
-func (f *clientHeartBeatProcesson) Process(ctx context.Context, rpcMessage message.RpcMessage) error {
+func (f *clientHeartBeatProcessor) Process(ctx context.Context, rpcMessage message.RpcMessage) error {
 	if msg, ok := rpcMessage.Body.(message.HeartBeatMessage); ok {
 		if !msg.Ping {
-			log.Infof("received PONG from {}", ctx)
+			log.Debug("received PONG from {}", ctx)
 		}
 	}
 	return nil

--- a/pkg/remoting/processor/client/client_heart_beat_processor_test.go
+++ b/pkg/remoting/processor/client/client_heart_beat_processor_test.go
@@ -71,7 +71,7 @@ func TestClientHeartBeatProcessor(t *testing.T) {
 	}
 
 	var ctx context.Context
-	var chbProcessor clientHeartBeatProcesson
+	var chbProcessor clientHeartBeatProcessor
 	// run tests
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/remoting/processor/client/rm_branch_commit_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_commit_processor.go
@@ -77,7 +77,7 @@ func (f *rmBranchCommitProcessor) Process(ctx context.Context, rpcMessage messag
 			BranchStatus: status,
 		},
 	}
-	err = getty.GetGettyRemotingClient().SendAsyncResponse(response)
+	err = getty.GetGettyRemotingClient().SendAsyncResponse(rpcMessage.ID, response)
 	if err != nil {
 		log.Errorf("send branch commit response error: {%#v}", err.Error())
 		return err

--- a/pkg/remoting/processor/client/rm_branch_rollback_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_rollback_processor.go
@@ -75,7 +75,7 @@ func (f *rmBranchRollbackProcessor) Process(ctx context.Context, rpcMessage mess
 			BranchStatus: status,
 		},
 	}
-	err = getty.GetGettyRemotingClient().SendAsyncResponse(response)
+	err = getty.GetGettyRemotingClient().SendAsyncResponse(rpcMessage.ID, response)
 	if err != nil {
 		log.Errorf("send branch rollback response error: {%#v}", err.Error())
 		return err


### PR DESCRIPTION
Which issue(s) this PR fixes:
fixs：https://github.com/seata/seata-go/issues/129
When the TCC global transaction commits, the first sub transaction can reconstruct the commit. When the server notifies the second sub transaction to commit, it prompts that the session cannot be found and outputs the error log

Special notes for your reviewer:
Does this PR introduce a user-facing change?: