### PR TITLE
opt: optimize comments and dead code

### DIFF
--- a/pkg/datasource/sql/driver.go
+++ b/pkg/datasource/sql/driver.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -101,14 +102,11 @@ type seataDriver struct {
 	target    driver.Driver
 }
 
+// Open never be called, because seataDriver implemented dri.DriverContext interface.
+// reference package: datasource/sql [https://cs.opensource.google/go/go/+/master:src/database/sql/sql.go;l=813]
+// and maybe the sql.BD will be call Driver() method, but it obtain the Driver is fron Connector that is proxed by seataConnector.
 func (d *seataDriver) Open(name string) (driver.Conn, error) {
-	conn, err := d.target.Open(name)
-	if err != nil {
-		log.Errorf("open db connection: %w", err)
-		return nil, err
-	}
-
-	return conn, nil
+	return nil, errors.New(("operation unsupport."))
 }
 
 func (d *seataDriver) OpenConnector(name string) (c driver.Connector, err error) {
@@ -161,7 +159,7 @@ func getOpenConnectorProxy(connector driver.Connector, dbType types.DBType, db *
 
 	if err := conf.validate(); err != nil {
 		log.Errorf("invalid conf: %w", err)
-		return connector, err
+		return nil, err
 	}
 
 	cfg, _ := mysql.ParseDSN(dataSourceName)
@@ -213,11 +211,9 @@ func (c *seataServerConfig) validate() error {
 }
 
 // loadConfig
-// TODO wait finish
 func loadConfig() *seataServerConfig {
-	// 先设置默认配置
-
-	// 从默认文件获取
+	// set default value first.
+	// todo read from configuration file.
 	return &seataServerConfig{
 		GroupID:    "DEFAULT_GROUP",
 		BranchType: branch.BranchTypeAT,

--- a/pkg/datasource/sql/driver_test.go
+++ b/pkg/datasource/sql/driver_test.go
@@ -75,7 +75,6 @@ func Test_seataATDriver_Open(t *testing.T) {
 		field = vv.FieldByName("target")
 
 		mockDriver := mock.NewMockTestDriver(ctrl)
-		mockDriver.EXPECT().Open(gomock.Any()).Return(mock.NewMockTestDriverConn(ctrl), nil)
 
 		reflectx.SetUnexportedField(field, mockDriver)
 
@@ -86,26 +85,8 @@ func Test_seataATDriver_Open(t *testing.T) {
 	})
 
 	conn, err := db.Conn(context.Background())
-	assert.NoError(t, err)
-
-	v := reflect.ValueOf(conn)
-	if v.Kind() == reflect.Ptr {
-		v = v.Elem()
-	}
-
-	field := v.FieldByName("dc")
-	fieldVal := reflectx.GetUnexportedField(field)
-
-	vv := reflect.ValueOf(fieldVal)
-	if vv.Kind() == reflect.Ptr {
-		vv = vv.Elem()
-	}
-
-	field = vv.FieldByName("ci")
-	fieldVal = reflectx.GetUnexportedField(field)
-
-	_, ok := fieldVal.(*ATConn)
-	assert.True(t, ok, "need return seata at connection")
+	assert.NotNil(t, err)
+	assert.Nil(t, conn)
 }
 
 func Test_seataATDriver_OpenConnector(t *testing.T) {


### PR DESCRIPTION
包含注释，返回值 typo 和一个 小的代码优化
1. Driver.Open 方法任何时候都不应该返回一个 target Driver 的简单代理，因为这会导致用户产生错误的判断
2. Driver.Open 方法在 DB.Open 方法中永远不会被调用，因为 Driver 实现了 OpenConnector 方法