### PR TITLE
feat(fence): implement fence use datasource proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,10 @@ require (
 	vimagination.zapto.org/byteio v0.0.0-20200222190125-d27cba0f0b10
 )
 
-require github.com/agiledragon/gomonkey/v2 v2.9.0
+require (
+	github.com/agiledragon/gomonkey v2.0.2+incompatible
+	github.com/agiledragon/gomonkey/v2 v2.9.0
+)
 
 require (
 	github.com/RoaringBitmap/roaring v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/Workiva/go-datastructures v1.0.52 h1:PLSK6pwn8mYdaoaCZEMsXBpBotr4HHn9abU0yMQt0NI=
 github.com/Workiva/go-datastructures v1.0.52/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
+github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
 github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=
 github.com/agiledragon/gomonkey/v2 v2.9.0 h1:PDiKKybR596O6FHW+RVSG0Z7uGCBNbmbUXh3uCNQ7Hc=
 github.com/agiledragon/gomonkey/v2 v2.9.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=

--- a/pkg/rm/tcc/fence/fence_driver.go
+++ b/pkg/rm/tcc/fence/fence_driver.go
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fence
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/pkg/errors"
+	"github.com/seata/seata-go/pkg/util/log"
+)
+
+const (
+	// SeataFenceMySQLDriver MySQL driver for fence
+	SeataFenceMySQLDriver = "seata-fence-mysql"
+)
+
+func init() {
+	sql.Register(SeataFenceMySQLDriver, &FenceDriver{
+		TargetDriver: &mysql.MySQLDriver{},
+	})
+}
+
+type FenceDriver struct {
+	TargetDriver driver.Driver
+	TargetDB     *sql.DB
+}
+
+func (fd *FenceDriver) Open(name string) (driver.Conn, error) {
+	return nil, errors.New("operation unsupported")
+}
+
+func (fd *FenceDriver) OpenConnector(name string) (connector driver.Connector, re error) {
+	connector = &dsnConnector{dsn: name, driver: fd.TargetDriver}
+	if driverCtx, ok := fd.TargetDriver.(driver.DriverContext); ok {
+		connector, re = driverCtx.OpenConnector(name)
+		if re != nil {
+			log.Errorf("open connector: %w", re)
+			return nil, re
+		}
+	}
+
+	fd.TargetDB = sql.OpenDB(connector)
+
+	return &SeataFenceConnector{
+		TargetConnector: connector,
+		TargetDB:        fd.TargetDB,
+	}, nil
+}
+
+type dsnConnector struct {
+	dsn    string
+	driver driver.Driver
+}
+
+func (connector *dsnConnector) Connect(_ context.Context) (driver.Conn, error) {
+	return connector.driver.Open(connector.dsn)
+}
+
+func (connector *dsnConnector) Driver() driver.Driver {
+	return connector.driver
+}
+
+type SeataFenceConnector struct {
+	TargetConnector driver.Connector
+	TargetDB        *sql.DB
+}
+
+func (connector *SeataFenceConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	targetConn, err := connector.TargetConnector.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FenceConn{
+		TargetConn: targetConn,
+		TargetDB:   connector.TargetDB,
+	}, nil
+}
+
+func (connector *SeataFenceConnector) Driver() driver.Driver {
+	return connector.TargetConnector.Driver()
+}

--- a/pkg/rm/tcc/fence/fence_driver_conn.go
+++ b/pkg/rm/tcc/fence/fence_driver_conn.go
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fence
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+
+	"github.com/pkg/errors"
+	"github.com/seata/seata-go/pkg/tm"
+	"github.com/seata/seata-go/pkg/util/log"
+)
+
+type FenceConn struct {
+	TargetConn driver.Conn
+	TargetDB   *sql.DB
+}
+
+func (c *FenceConn) ResetSession(ctx context.Context) error {
+	resetter, ok := c.TargetConn.(driver.SessionResetter)
+	if !ok {
+		return driver.ErrSkip
+	}
+
+	return resetter.ResetSession(ctx)
+}
+
+func (c *FenceConn) Prepare(query string) (driver.Stmt, error) {
+	return c.TargetConn.Prepare(query)
+}
+
+func (c *FenceConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	return c.TargetConn.Prepare(query)
+}
+
+func (c *FenceConn) Exec(query string, args []driver.Value) (driver.Result, error) {
+	execer, ok := c.TargetConn.(driver.Execer)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	return execer.Exec(query, args)
+}
+
+func (c *FenceConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	execerContext, ok := c.TargetConn.(driver.ExecerContext)
+	if !ok {
+		values := make([]driver.Value, 0, len(args))
+		for i := range args {
+			values = append(values, args[i].Value)
+		}
+		return c.Exec(query, values)
+	}
+
+	return execerContext.ExecContext(ctx, query, args)
+}
+
+func (c *FenceConn) Query(query string, args []driver.Value) (driver.Rows, error) {
+	queryer, ok := c.TargetConn.(driver.Queryer)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	return queryer.Query(query, args)
+}
+
+func (c *FenceConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	QueryerContext, ok := c.TargetConn.(driver.QueryerContext)
+	if !ok {
+		values := make([]driver.Value, 0, len(args))
+
+		for i := range args {
+			values = append(values, args[i].Value)
+		}
+
+		return c.Query(query, values)
+	}
+
+	return QueryerContext.QueryContext(ctx, query, args)
+}
+
+func (c *FenceConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("operation unsupport")
+}
+
+func (c *FenceConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	beginer, ok := c.TargetConn.(driver.ConnBeginTx)
+	if !ok {
+		return nil, errors.New("operation unsupported")
+	}
+
+	tx, err := beginer.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if !tm.IsSeataContext(ctx) {
+		return nil, errors.New("there is not seata context")
+	}
+
+	// check if have been begin fence tx
+	if tm.IsFenceTxBegin(ctx) {
+		return tx, nil
+	}
+
+	tm.SetFenceTxBeginedFlag(ctx, true)
+
+	fenceTx, err := c.TargetDB.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			if err := fenceTx.Rollback(); err != nil {
+				log.Error(err)
+			}
+
+			// although it have not any db operations yet, is still rollback to avoid leak tx.
+			if err := tx.Rollback(); err != nil {
+				log.Error(err)
+			}
+		}
+	}()
+
+	// do fence operations
+	emptyCallback := func() error {
+		return nil
+	}
+
+	if err := WithFence(ctx, fenceTx, emptyCallback); err != nil {
+		return nil, err
+	}
+
+	return &FenceTx{
+		Ctx:           ctx,
+		TargetTx:      tx,
+		TargetFenceTx: fenceTx,
+	}, nil
+}
+
+func (c *FenceConn) Close() error {
+	return c.TargetConn.Close()
+}

--- a/pkg/rm/tcc/fence/fence_driver_conn_test.go
+++ b/pkg/rm/tcc/fence/fence_driver_conn_test.go
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fence
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBegin(t *testing.T) {
+	tx, err := (&FenceConn{}).Begin()
+	assert.NotNil(t, err)
+	assert.Nil(t, tx)
+}

--- a/pkg/rm/tcc/fence/fence_driver_tx.go
+++ b/pkg/rm/tcc/fence/fence_driver_tx.go
@@ -1,0 +1,37 @@
+package fence
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+
+	"github.com/seata/seata-go/pkg/tm"
+)
+
+type FenceTx struct {
+	Ctx           context.Context
+	TargetTx      driver.Tx
+	TargetFenceTx *sql.Tx
+}
+
+func (tx *FenceTx) Commit() error {
+	if err := tx.TargetTx.Commit(); err != nil {
+		return err
+	}
+
+	tx.clearFenceTx()
+	return tx.TargetFenceTx.Commit()
+}
+
+func (tx *FenceTx) Rollback() error {
+	if err := tx.TargetTx.Rollback(); err != nil {
+		return err
+	}
+
+	tx.clearFenceTx()
+	return tx.TargetFenceTx.Rollback()
+}
+
+func (tx *FenceTx) clearFenceTx() {
+	tm.SetFenceTxBeginedFlag(tx.Ctx, false)
+}

--- a/pkg/tm/context.go
+++ b/pkg/tm/context.go
@@ -50,7 +50,9 @@ type BusinessActionContext struct {
 }
 
 type ContextVariable struct {
-	FencePhase            enum.FencePhase
+	FencePhase     enum.FencePhase
+	FenceTxBegined bool
+
 	BusinessActionContext *BusinessActionContext
 	// GlobalTransaction Represent seata ctx is a global transaction
 	GlobalTransaction
@@ -194,4 +196,18 @@ func GetFencePhase(ctx context.Context) enum.FencePhase {
 		return variable.(*ContextVariable).FencePhase
 	}
 	return enum.FencePhaseNotExist
+}
+
+func SetFenceTxBeginedFlag(ctx context.Context, fenceTxBegined bool) {
+	if variable := ctx.Value(seataContextVariable); variable != nil {
+		variable.(*ContextVariable).FenceTxBegined = fenceTxBegined
+	}
+}
+
+func IsFenceTxBegin(ctx context.Context) bool {
+	if variable := ctx.Value(seataContextVariable); variable != nil {
+		return variable.(*ContextVariable).FenceTxBegined
+	}
+
+	return false
 }


### PR DESCRIPTION
使用数据源代理实现防悬挂：
![image](https://user-images.githubusercontent.com/50058173/218255667-4f7891e7-0138-442f-8313-f14fc4b760e0.png)
**背景**：在原有的实现中用户每次都要调 WithFence() 接口来启用防悬挂功能，比较繁琐
**解决**：将防悬挂操作开启时机绑定在 BeginTx、Commit、Rollback 三个操作中，用户可以原生数据库操作的体验使用防悬挂功能
**实现**：实现 driver.Driver, driver.Conn, driver.Tx 接口，代理实际驱动类型，在 Conn.BeginTx 中进行防悬挂操作，在 Tx.Commit、Tx.Rollback 中提交或回滚防悬挂操作
