### PR TITLE
fix(tm): fix missing value of context

### DIFF
--- a/pkg/tm/transaction_executor.go
+++ b/pkg/tm/transaction_executor.go
@@ -54,9 +54,8 @@ func WithGlobalTx(ctx context.Context, gc *GtxConfig, business CallbackWithCtx) 
 		ctx = InitSeataContext(ctx)
 	}
 
-	// use new context to process current global transaction.
 	if IsGlobalTx(ctx) {
-		ctx = transferTx(ctx)
+		clearTxConf(ctx)
 	}
 
 	if re = begin(ctx, gc); re != nil {
@@ -202,10 +201,7 @@ func useExistGtx(ctx context.Context, gc *GtxConfig) {
 	}
 }
 
-// transferTx transfer the gtx into a new ctx from old ctx.
-// use it to implement suspend and resume instead of seata java
-func transferTx(ctx context.Context) context.Context {
-	newCtx := InitSeataContext(context.Background())
-	SetXID(newCtx, GetXID(ctx))
-	return newCtx
+// clearTxConf When using global transactions in local mode, you need to clear tx config to use the propagation of global transactions.
+func clearTxConf(ctx context.Context) {
+	SetTx(ctx, &GlobalTransaction{Xid: GetXID(ctx)})
 }

--- a/pkg/tm/transaction_executor_test.go
+++ b/pkg/tm/transaction_executor_test.go
@@ -318,11 +318,22 @@ func TestCommitOrRollback(t *testing.T) {
 	}
 }
 
-func TestTransferTx(t *testing.T) {
+func TestClearTxConf(t *testing.T) {
 	ctx := InitSeataContext(context.Background())
-	SetXID(ctx, "123456")
-	newCtx := transferTx(ctx)
-	assert.Equal(t, GetXID(ctx), GetXID(newCtx))
+
+	SetTx(ctx, &GlobalTransaction{
+		Xid:      "123456",
+		TxName:   "MockTxName",
+		TxStatus: message.GlobalStatusBegin,
+		TxRole:   Launcher,
+	})
+
+	clearTxConf(ctx)
+
+	assert.Equal(t, "123456", GetXID(ctx))
+	assert.Equal(t, UnKnow, *GetTxRole(ctx))
+	assert.Equal(t, message.GlobalStatusUnKnown, *GetTxStatus(ctx))
+	assert.Equal(t, "", GetTxName(ctx))
 }
 
 func TestUseExistGtx(t *testing.T) {


### PR DESCRIPTION
When using global transactions, directly using the new context object to replace the old one will cause loss of other context information