### PR TITLE
feat(undo): add the use of undo log serialization

### DIFF
--- a/pkg/datasource/sql/undo/base/undo.go
+++ b/pkg/datasource/sql/undo/base/undo.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -31,13 +30,12 @@ import (
 	"github.com/seata/seata-go/pkg/datasource/sql/types"
 	"github.com/seata/seata-go/pkg/datasource/sql/undo"
 	"github.com/seata/seata-go/pkg/datasource/sql/undo/factor"
+	"github.com/seata/seata-go/pkg/datasource/sql/undo/parser"
+	"github.com/seata/seata-go/pkg/util/collection"
 	"github.com/seata/seata-go/pkg/util/log"
 )
 
 const (
-	PairSplit = "&"
-	KvSplit   = "="
-
 	compressorTypeKey       = "compressorTypeKey"
 	serializerKey           = "serializerKey"
 	defaultUndoLogTableName = " undo_log "
@@ -205,16 +203,12 @@ func (m *BaseUndoLogManager) FlushUndoLog(tranCtx *types.TransactionContext, con
 		Logs:     sqlUndoLogs,
 	}
 
-	// use defalut encode
-	rollbackInfo, err := json.Marshal(branchUndoLog)
-	if err != nil {
-		return err
-	}
-
 	parseContext := make(map[string]string, 0)
 	parseContext[serializerKey] = "jackson"
 	parseContext[compressorTypeKey] = "NONE"
-	undoLogContent, err := json.Marshal(parseContext)
+	undoLogContent := m.encodeUndoLogCtx(parseContext)
+
+	rollbackInfo, err := m.serializeBranchUndoLog(&branchUndoLog, parseContext[serializerKey])
 	if err != nil {
 		return err
 	}
@@ -295,9 +289,19 @@ func (m *BaseUndoLogManager) Undo(ctx context.Context, dbType types.DBType, xid 
 			return nil
 		}
 
-		// todo use serializer and decode
-		var branchUndoLog undo.BranchUndoLog
-		if err = json.Unmarshal(record.RollbackInfo, &branchUndoLog); err != nil {
+		var logCtx map[string]string
+		if record.Context != nil && string(record.Context) != "" {
+			logCtx = m.decodeUndoLogCtx(record.Context)
+		}
+
+		if logCtx == nil {
+			return fmt.Errorf("undo log context not exist in record %+v", record)
+		}
+
+		rbInfo := m.decompressRollbackInfo(record.RollbackInfo, logCtx)
+
+		var branchUndoLog *undo.BranchUndoLog
+		if branchUndoLog, err = m.deserializeBranchUndoLog(rbInfo, logCtx); err != nil {
 			return err
 		}
 
@@ -355,15 +359,19 @@ func (m *BaseUndoLogManager) insertUndoLogWithGlobalFinished(ctx context.Context
 	parseContext := make(map[string]string, 0)
 	parseContext[serializerKey] = "jackson"
 	parseContext[compressorTypeKey] = "NONE"
-	undoLogContent, err := json.Marshal(parseContext)
-	if err != nil {
+	undoLogContent := m.encodeUndoLogCtx(parseContext)
+
+	logParse,err:= parser.GetCache().Load(parseContext[serializerKey])
+	if err!=nil{
 		return err
 	}
+
+	rbInfo := logParse.GetDefaultContent()
 
 	record := undo.UndologRecord{
 		BranchID:     branchID,
 		XID:          xid,
-		RollbackInfo: []byte("{}"),
+		RollbackInfo: rbInfo,
 		LogStatus:    UndoLogStatusGlobalFinished,
 		Context:      undoLogContent,
 	}
@@ -450,38 +458,8 @@ func (m *BaseUndoLogManager) canUndo(state int32) bool {
 	return state == UndoLogStatusNormal
 }
 
-// parseContext parse undo context
-func (m *BaseUndoLogManager) parseContext(str string) map[string]string {
-	return m.DecodeMap(str)
-}
-
-// DecodeMap Decode undo log context string to map
-func (m *BaseUndoLogManager) DecodeMap(str string) map[string]string {
-	res := make(map[string]string)
-
-	if str == "" {
-		return nil
-	}
-
-	strSlice := strings.Split(str, PairSplit)
-	if len(strSlice) == 0 {
-		return nil
-	}
-
-	for key, _ := range strSlice {
-		kv := strings.Split(strSlice[key], KvSplit)
-		if len(kv) != 2 {
-			continue
-		}
-
-		res[kv[0]] = kv[1]
-	}
-
-	return res
-}
-
-// getRollbackInfo parser rollback info
-func (m *BaseUndoLogManager) getRollbackInfo(rollbackInfo []byte, undoContext map[string]string) []byte {
+// decompressRollbackInfo parser rollback info
+func (m *BaseUndoLogManager) decompressRollbackInfo(rollbackInfo []byte, undoContext map[string]string) []byte {
 	// Todo use compressor
 	// get compress type
 	/*compressorType, ok := undoContext[constant.compressorTypeKey]
@@ -499,4 +477,41 @@ func (m *BaseUndoLogManager) getSerializer(undoLogContext map[string]string) (se
 	}
 	serializer, _ = undoLogContext[serializerKey]
 	return
+}
+
+func (m *BaseUndoLogManager) deserializeBranchUndoLog(rbInfo []byte, logCtx map[string]string) (*undo.BranchUndoLog, error) {
+	var (
+		err       error
+		logParser parser.UndoLogParser
+	)
+
+	if serialzerType := m.getSerializer(logCtx); serialzerType != "" {
+		if logParser, err = parser.GetCache().Load(serialzerType); err != nil {
+			return nil, err
+		}
+	}
+
+	var branchUndoLog *undo.BranchUndoLog
+	if branchUndoLog, err = logParser.Decode(rbInfo); err != nil {
+		return nil, err
+	}
+
+	return branchUndoLog, nil
+}
+
+func (m *BaseUndoLogManager) serializeBranchUndoLog(log *undo.BranchUndoLog, serializerType string) ([]byte, error) {
+	logParser, err := parser.GetCache().Load(serializerType)
+	if err != nil {
+		return nil, err
+	}
+
+	return logParser.Encode(log)
+}
+
+func (m *BaseUndoLogManager) encodeUndoLogCtx(undoLogCtx map[string]string) []byte {
+	return collection.EncodeMap(undoLogCtx)
+}
+
+func (m *BaseUndoLogManager) decodeUndoLogCtx(undoLogCtx []byte) map[string]string {
+	return collection.DecodeMap(undoLogCtx)
 }

--- a/pkg/datasource/sql/undo/parser/const.go
+++ b/pkg/datasource/sql/undo/parser/const.go
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+const (
+	DefaultSerializer = "jackson"
+)

--- a/pkg/datasource/sql/undo/parser/parser_api.go
+++ b/pkg/datasource/sql/undo/parser/parser_api.go
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import "github.com/seata/seata-go/pkg/datasource/sql/undo"
+
+// The interface Undo log parser.
+type UndoLogParser interface {
+
+	// Get the name of parser;
+	// return the name of parser
+	GetName() string
+
+	// Get default context of this parser
+	// return the default content if undo log is empty
+	GetDefaultContent() []byte
+
+	// Encode branch undo log to byte array.
+	// param branchUndoLog the branch undo log
+	// return the byte array
+	Encode(branchUndoLog *undo.BranchUndoLog) ([]byte, error)
+
+	// Decode byte array to branch undo log.
+	// param bytes the byte array
+	// return the branch undo log
+	Decode(bytes []byte) (*undo.BranchUndoLog, error)
+}

--- a/pkg/datasource/sql/undo/parser/parser_cache.go
+++ b/pkg/datasource/sql/undo/parser/parser_cache.go
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"fmt"
+	"sync"
+)
+
+var (
+	once  sync.Once
+	cache *UndoLogParserCache
+)
+
+// The type Undo log parser factory.
+type UndoLogParserCache struct {
+	// serializerName --> UndoLogParser
+	serializerNameToParser map[string]UndoLogParser
+}
+
+func initCache() {
+	cache = &UndoLogParserCache{
+		serializerNameToParser: make(map[string]UndoLogParser, 0),
+	}
+
+	cache.store(&JacksonParser{})
+}
+
+func GetCache() *UndoLogParserCache {
+	once.Do(initCache)
+
+	return cache
+}
+
+// Gets default UndoLogParser instance.
+// return the instance
+func (ulpc *UndoLogParserCache) GetDefault() (UndoLogParser, error) {
+	return ulpc.Load(DefaultSerializer)
+}
+
+// Gets UndoLogParser by name
+// param name parser name
+// return the UndoLogParser
+func (ulpc *UndoLogParserCache) Load(name string) (UndoLogParser, error) {
+	if parser, ok := ulpc.serializerNameToParser[name]; ok && parser != nil {
+		return parser, nil
+	}
+
+	return nil, fmt.Errorf("undo log parser type %v not found", name)
+}
+
+func (ulpc *UndoLogParserCache) store(parser UndoLogParser) {
+	ulpc.serializerNameToParser[parser.GetName()] = parser
+}

--- a/pkg/datasource/sql/undo/parser/parser_cache_test.go
+++ b/pkg/datasource/sql/undo/parser/parser_cache_test.go
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitCache(t *testing.T) {
+	assert.Nil(t, cache)
+	initCache()
+	assert.NotNil(t, cache)
+}
+
+func TestGetCache(t *testing.T) {
+	assert.NotNil(t, GetCache())
+}
+
+func TestGetDefault(t *testing.T) {
+	logParser, err := GetCache().GetDefault()
+	assert.Nil(t, err)
+	assert.NotNil(t, logParser)
+	assert.Equal(t, DefaultSerializer, logParser.GetName())
+}
+
+func TestLoad(t *testing.T) {
+	jacksonParser, err := GetCache().Load("jackson")
+	assert.Nil(t, err)
+	assert.NotNil(t, jacksonParser)
+}

--- a/pkg/datasource/sql/undo/parser/parser_jackson.go
+++ b/pkg/datasource/sql/undo/parser/parser_jackson.go
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"encoding/json"
+
+	"github.com/seata/seata-go/pkg/datasource/sql/undo"
+)
+
+type JacksonParser struct {
+}
+
+// Get the name of parser;
+// return the name of parser
+func (j *JacksonParser) GetName() string {
+	return "jackson"
+}
+
+// Get default context of this parser
+// return the default content if undo log is empty
+func (j *JacksonParser) GetDefaultContent() []byte {
+	return []byte("{}")
+}
+
+// Encode branch undo log to byte array.
+// param branchUndoLog the branch undo log
+// return the byte array
+func (j *JacksonParser) Encode(branchUndoLog *undo.BranchUndoLog) ([]byte, error) {
+	bytes, err := json.Marshal(branchUndoLog)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
+}
+
+// Decode byte array to branch undo log.
+// param bytes the byte array
+// return the branch undo log
+func (j *JacksonParser) Decode(bytes []byte) (*undo.BranchUndoLog, error) {
+	var branchUndoLog *undo.BranchUndoLog
+	if err := json.Unmarshal(bytes, &branchUndoLog); err != nil {
+		return nil, err
+	}
+
+	return branchUndoLog, nil
+}

--- a/pkg/datasource/sql/undo/parser/parser_jackson_test.go
+++ b/pkg/datasource/sql/undo/parser/parser_jackson_test.go
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/seata/seata-go/pkg/datasource/sql/undo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetName(t *testing.T) {
+	assert.Equal(t, "jackson", (&JacksonParser{}).GetName())
+}
+
+func TestGetDefaultContext(t *testing.T) {
+	assert.Equal(t, []byte("{}"), (&JacksonParser{}).GetDefaultContent())
+}
+
+func TestEncode(t *testing.T) {
+	TestCases := []struct {
+		CaseName    string
+		UndoLog     *undo.BranchUndoLog
+		ExpectErr   bool
+		ExpectBytes string
+	}{
+		{
+			CaseName: "pass",
+			UndoLog: &undo.BranchUndoLog{
+				Xid:      "123456",
+				BranchID: 123456,
+				Logs:     []undo.SQLUndoLog{},
+			},
+			ExpectErr:   false,
+			ExpectBytes: `{"xid":"123456","branchId":123456,"sqlUndoLogs":[]}`,
+		},
+	}
+
+	for _, Case := range TestCases {
+		t.Run(Case.CaseName, func(t *testing.T) {
+			logParser := &JacksonParser{}
+			bytes, err := logParser.Encode(Case.UndoLog)
+			if Case.ExpectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, Case.ExpectBytes, string(bytes))
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	TestCases := []struct {
+		CaseName      string
+		ExpectUndoLog undo.BranchUndoLog
+		ExpectErr     bool
+		InputBytes    string
+	}{
+		{
+			CaseName: "pass",
+			ExpectUndoLog: undo.BranchUndoLog{
+				Xid:      "123456",
+				BranchID: 123456,
+				Logs:     []undo.SQLUndoLog{},
+			},
+			ExpectErr:  false,
+			InputBytes: `{"xid":"123456","branchId":123456,"sqlUndoLogs":[]}`,
+		},
+	}
+
+	for _, Case := range TestCases {
+		t.Run(Case.CaseName, func(t *testing.T) {
+			logParser := &JacksonParser{}
+			undoLog, err := logParser.Decode([]byte(Case.InputBytes))
+			if Case.ExpectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, undoLog.Xid, Case.ExpectUndoLog.Xid)
+			assert.Equal(t, undoLog.BranchID, Case.ExpectUndoLog.BranchID)
+			assert.Equal(t, len(undoLog.Logs), len(Case.ExpectUndoLog.Logs))
+		})
+	}
+
+}

--- a/pkg/datasource/sql/undo/undo.go
+++ b/pkg/datasource/sql/undo/undo.go
@@ -163,18 +163,6 @@ func (s SQLUndoLog) SetTableMeta(tableMeta *types.TableMeta) {
 	}
 }
 
-// UndoLogParser
-type UndoLogParser interface {
-	// GetName
-	GetName() string
-	// GetDefaultContent
-	GetDefaultContent() []byte
-	// Encode
-	Encode(l BranchUndoLog) []byte
-	// Decode
-	Decode(b []byte) BranchUndoLog
-}
-
 type UndoLogBuilder interface {
 	BeforeImage(ctx context.Context, execCtx *types.ExecContext) ([]*types.RecordImage, error)
 	AfterImage(ctx context.Context, execCtx *types.ExecContext, beforImages []*types.RecordImage) ([]*types.RecordImage, error)

--- a/pkg/util/collection/collection.go
+++ b/pkg/util/collection/collection.go
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package collection
+
+import "strings"
+
+const (
+	KvSplit   = "="
+	PairSplit = "&"
+)
+
+var (
+	kvSplitBytes   = []byte(KvSplit)
+	pairSplitBytes = []byte(PairSplit)
+)
+
+func EncodeMap(dataMap map[string]string) []byte {
+	if dataMap == nil {
+		return nil
+	}
+
+	bytes := make([]byte, 0)
+	if len(dataMap) == 0 {
+		return bytes
+	}
+
+	for k, v := range dataMap {
+		bytes = append(bytes, []byte(k)...)
+		bytes = append(bytes, kvSplitBytes...)
+		bytes = append(bytes, []byte(v)...)
+		bytes = append(bytes, pairSplitBytes...)
+	}
+
+	return bytes[:len(bytes)-1]
+}
+
+func DecodeMap(data []byte) map[string]string {
+	if data == nil {
+		return nil
+	}
+
+	ctxMap := make(map[string]string, 0)
+
+	dataStr := string(data)
+	if dataStr == "" {
+		return ctxMap
+	}
+
+	kvPairs := strings.Split(dataStr, PairSplit)
+	if len(kvPairs) == 0 {
+		return ctxMap
+	}
+
+	for _, kvPair := range kvPairs {
+		if kvPair == "" {
+			continue
+		}
+
+		kvs := strings.Split(kvPair, KvSplit)
+		if len(kvs) != 2 {
+			continue
+		}
+
+		ctxMap[kvs[0]] = kvs[1]
+	}
+
+	return ctxMap
+}


### PR DESCRIPTION
集成 undo log 序列化并实现了默认的 json parser，由于 ColumnImage 实现了 Json 的序列化，反序列化的特殊处理，因此在 JacksonParser 中不需要进行重复实现
![image](https://user-images.githubusercontent.com/50058173/218298755-37341904-a7c0-4b57-b000-dfa2b85ef8b9.png)
