### PR TITLE
fix buildLockKey failed

### DIFF
--- a/pkg/datasource/sql/exec/at/select_for_update_executor_test.go
+++ b/pkg/datasource/sql/exec/at/select_for_update_executor_test.go
@@ -76,9 +76,7 @@ func TestBuildSelectPKSQL(t *testing.T) {
 
 	selSQL, err := e.buildSelectPKSQL(ctx.SelectStmt, &metaData)
 	assert.Nil(t, err)
-	equal := "SELECT SQL_NO_CACHE order_id,id FROM t_user WHERE age>? FOR UPDATE" == selSQL ||
-		"SELECT SQL_NO_CACHE id,order_id FROM t_user WHERE age>? FOR UPDATE" == selSQL
-	assert.Equal(t, equal, true)
+	assert.Equal(t, "SELECT SQL_NO_CACHE id,order_id FROM t_user WHERE age>? FOR UPDATE" == selSQL, true)
 }
 
 func TestBuildLockKey(t *testing.T) {
@@ -123,6 +121,7 @@ func TestBuildLockKey(t *testing.T) {
 				ColumnName:         "age",
 			},
 		},
+		ColumnNames: []string{"id", "order_id", "age"},
 	}
 	rows := mockRows{}
 	lockKey := e.buildLockKey(rows, &metaData)

--- a/pkg/datasource/sql/types/meta.go
+++ b/pkg/datasource/sql/types/meta.go
@@ -20,6 +20,7 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"sort"
 )
 
 // ColumnMeta
@@ -119,6 +120,18 @@ func (m TableMeta) GetPrimaryKeyOnlyName() []string {
 			}
 		}
 	}
+
+	// need sort again according the m.ColumnNames
+	order := make(map[string]int, len(m.ColumnNames))
+	for i, name := range m.ColumnNames {
+		order[name] = i
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if order == nil {
+			return false
+		}
+		return order[keys[i]] < order[keys[j]]
+	})
 	return keys
 }
 

--- a/pkg/datasource/sql/types/meta.go
+++ b/pkg/datasource/sql/types/meta.go
@@ -127,9 +127,6 @@ func (m TableMeta) GetPrimaryKeyOnlyName() []string {
 		order[name] = i
 	}
 	sort.Slice(keys, func(i, j int) bool {
-		if order == nil {
-			return false
-		}
 		return order[keys[i]] < order[keys[j]]
 	})
 	return keys


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #496 

**Special notes for your reviewer**:

太长不看版
TableMeta 中获取的 PrimaryKey的 columns 顺序和实际 data 中 PrimaryKey 的 columns 顺序不一致导致类型转换发生错误

详细分析版
1. `buildLockKey` 是用来生成 LockKey, 函数会扫描每一行并仅取出 `primarykey`，然后以此拼成 `LockKey`
2. 取出每一行的 primarykey 中的值时，需要经过类型转换的过程，需要使用 **类型** 和 **值** 两个参数
3. 类型 是从 TableMeta 中获取的，实际是通过 GetPrimaryKeyOnlyName 用来获取, PrimaryKey 中的 Columns 顺序随机
4. 值 是 sqlRows 扫描每一行数据得到的 columns, 顺序是按照 TableMeta.ColumnNames 顺序
5. 例如类型的顺序[id(int), order_id(varchar)], 而值的顺序是[order_id(varchar), id(int)] 就发生报错

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```