### PR TITLE
fix: resolve busy buffer error in xa mode

### DIFF
--- a/pkg/datasource/sql/conn_xa_test.go
+++ b/pkg/datasource/sql/conn_xa_test.go
@@ -44,13 +44,12 @@ type mysqlMockRows struct {
 }
 
 func (m *mysqlMockRows) Columns() []string {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (m *mysqlMockRows) Close() error {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 func (m *mysqlMockRows) Next(dest []driver.Value) error {
@@ -141,7 +140,7 @@ func initXAConnTestResource(t *testing.T) (*gomock.Controller, *sql.DB, *mockSQL
 
 	mockMgr := initMockResourceManager(branch.BranchTypeXA, ctrl)
 	_ = mockMgr
-	//db, err := sql.Open("seata-xa-mysql", "root:seata_go@tcp(127.0.0.1:3306)/seata_go_test?multiStatements=true")
+	// db, err := sql.Open("seata-xa-mysql", "root:seata_go@tcp(127.0.0.1:3306)/seata_go_test?multiStatements=true")
 	db, err := sql.Open("seata-xa-mysql", "root:12345678@tcp(127.0.0.1:3306)/seata_client?multiStatements=true&interpolateParams=true")
 	if err != nil {
 		t.Fatal(err)
@@ -174,7 +173,6 @@ func initXAConnTestResource(t *testing.T) (*gomock.Controller, *sql.DB, *mockSQL
 }
 
 func TestXAConn_ExecContext(t *testing.T) {
-
 	ctrl, db, mi, ti := initXAConnTestResource(t)
 	defer func() {
 		ctrl.Finish()
@@ -328,5 +326,4 @@ func TestXAConn_BeginTx(t *testing.T) {
 
 		assert.Equal(t, int32(1), atomic.LoadInt32(&comitCnt))
 	})
-
 }

--- a/pkg/datasource/sql/connector.go
+++ b/pkg/datasource/sql/connector.go
@@ -21,10 +21,11 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
-	"github.com/go-sql-driver/mysql"
 	"io"
 	"reflect"
 	"sync"
+
+	"github.com/go-sql-driver/mysql"
 
 	"github.com/seata/seata-go/pkg/datasource/sql/types"
 	"github.com/seata/seata-go/pkg/util/log"
@@ -148,7 +149,7 @@ func (c *seataConnector) dbVersion(ctx context.Context, conn driver.Conn) (strin
 		log.Errorf("seata connector get the xa mysql version err:%v", err)
 		return "", err
 	}
-
+	defer res.Close()
 	dest := make([]driver.Value, 1)
 	var version string
 


### PR DESCRIPTION
**What this PR does**:
resolve busy buffer error in xa mode
**Which issue(s) this PR fixes**:
Fixes #549 

**Special notes for your reviewer**:
测试XA事务模式下的select for update遇到的错误：go-sql-driver向mysql发送xa start时会抛出ErrBusyBuffer错误，导致全局事务回滚。
![1](https://github.com/seata/seata-go/assets/12913198/c36f4b5e-22c3-4aa2-99b6-90cd89bce36f)

conn.buf中的数据
![2](https://github.com/seata/seata-go/assets/12913198/c48fe5df-c6e0-493d-aeda-b5b836d13a38)

一个类似问题的issue：https://github.com/go-sql-driver/mysql/issues/977。
因此，怀疑在执行xa start之前，连接被用于某个查询操作，但driver.Rows没有关闭，导致再次使用连接时，连接的buf是占用状态。

原来的connector.go dbVersion函数中没有对res进行关闭，导致连接的buf被旧数据占用，buf中的数据也确实是MySql的版本信息。
![3](https://github.com/seata/seata-go/assets/12913198/7bc258a3-c6b2-49b9-a0a0-b2c03137460f)
加上defer res.Close()可以解决问题。

该问题只会在xa模式下出现。
![image](https://github.com/seata/seata-go/assets/12913198/57e8efcc-74bd-4413-bb88-415ff62b1e9a)