### PR TITLE
perf: optimize the performance of XA transactions

### DIFF
--- a/pkg/datasource/sql/connector.go
+++ b/pkg/datasource/sql/connector.go
@@ -20,14 +20,11 @@ package sql
 import (
 	"context"
 	"database/sql/driver"
-	"errors"
-	"github.com/go-sql-driver/mysql"
-	"io"
-	"reflect"
 	"sync"
 
+	"github.com/go-sql-driver/mysql"
+
 	"github.com/seata/seata-go/pkg/datasource/sql/types"
-	"github.com/seata/seata-go/pkg/util/log"
 )
 
 type seataATConnector struct {
@@ -117,16 +114,6 @@ func (c *seataConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// get the version of mysql for xa.
-	if c.transType == types.XAMode {
-		version, err := c.dbVersion(ctx, conn)
-		if err != nil {
-			return nil, err
-		}
-		c.res.SetDbVersion(version)
-	}
-
 	return &Conn{
 		targetConn: conn,
 		res:        c.res,
@@ -135,44 +122,6 @@ func (c *seataConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		dbName:     c.cfg.DBName,
 		dbType:     types.DBTypeMySQL,
 	}, nil
-}
-
-func (c *seataConnector) dbVersion(ctx context.Context, conn driver.Conn) (string, error) {
-	queryConn, isQueryContext := conn.(driver.QueryerContext)
-	if !isQueryContext {
-		return "", errors.New("get db version error for unexpected driver conn")
-	}
-
-	res, err := queryConn.QueryContext(ctx, "SELECT VERSION()", nil)
-	if err != nil {
-		log.Errorf("seata connector get the xa mysql version err:%v", err)
-		return "", err
-	}
-
-	dest := make([]driver.Value, 1)
-	var version string
-
-	if err = res.Next(dest); err != nil {
-		if err == io.EOF {
-			return version, nil
-		}
-		return "", err
-	}
-	if len(dest) != 1 {
-		return "", errors.New("get the mysql version is not column 1")
-	}
-
-	switch reflect.TypeOf(dest[0]).Kind() {
-	case reflect.Slice, reflect.Array:
-		val := reflect.ValueOf(dest[0]).Bytes()
-		version = string(val)
-	case reflect.String:
-		version = reflect.ValueOf(dest[0]).String()
-	default:
-		return "", errors.New("get the mysql version is not a string")
-	}
-
-	return version, nil
 }
 
 // Driver returns the underlying Driver of the Connector,

--- a/pkg/datasource/sql/db.go
+++ b/pkg/datasource/sql/db.go
@@ -29,6 +29,7 @@ import (
 	"github.com/seata/seata-go/pkg/datasource/sql/undo"
 	"github.com/seata/seata-go/pkg/datasource/sql/util"
 	"github.com/seata/seata-go/pkg/protocol/branch"
+	"github.com/seata/seata-go/pkg/util/log"
 )
 
 type dbOption func(db *DBResource)
@@ -123,6 +124,16 @@ func (db *DBResource) GetResourceGroupId() string {
 }
 
 func (db *DBResource) init() {
+	ctx := context.Background()
+	conn, err := db.connector.Connect(ctx)
+	if err != nil {
+		log.Errorf("connect: %w", err)
+	}
+	version, err := selectDBVersion(ctx, conn)
+	if err != nil {
+		log.Errorf("select db version: %w", err)
+	}
+	db.SetDbVersion(version)
 	db.checkDbVersion()
 }
 

--- a/pkg/datasource/sql/driver.go
+++ b/pkg/datasource/sql/driver.go
@@ -199,7 +199,7 @@ func selectDBVersion(ctx context.Context, conn driver.Conn) (string, error) {
 
 	res, err := queryConn.QueryContext(ctx, "SELECT VERSION()", nil)
 	if err != nil {
-		log.Errorf("seata connector get the xa mysql version err:%v", err)
+		log.Errorf("get db version error:%v", err)
 		return "", err
 	}
 
@@ -213,7 +213,7 @@ func selectDBVersion(ctx context.Context, conn driver.Conn) (string, error) {
 		return "", err
 	}
 	if len(dest) != 1 {
-		return "", errors.New("get the mysql version is not column 1")
+		return "", errors.New("get db version is not column 1")
 	}
 
 	switch reflect.TypeOf(dest[0]).Kind() {
@@ -223,7 +223,7 @@ func selectDBVersion(ctx context.Context, conn driver.Conn) (string, error) {
 	case reflect.String:
 		version = reflect.ValueOf(dest[0]).String()
 	default:
-		return "", errors.New("get the mysql version is not a string")
+		return "", errors.New("get db version is not a string")
 	}
 
 	return version, nil

--- a/pkg/rm/tcc/fence/fence_driver_tx.go
+++ b/pkg/rm/tcc/fence/fence_driver_tx.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fence
 
 import (

--- a/pkg/rm/tcc/fence/fennce_driver_test.go
+++ b/pkg/rm/tcc/fence/fennce_driver_test.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fence
 
 import (


### PR DESCRIPTION
**What this PR does**:

取消了每次执行XA事务时查询数据库版本的操作，把版本查询放在了getOpenConnectorProxy过程中，只需要查一次即可。

**Which issue(s) this PR fixes**:
Fixes #553 