### PR TITLE
fix: use mirromutth/mysql-action instead of icomponent/mysql-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,14 +45,13 @@ jobs:
 
       # run mysql server
       - name: Create mysql database auth
-        uses: icomponent/mysql-action@master
+        uses: mirromutth/mysql-action@v1.1
         with:
-          VERSION: 5.7
-          CONTAINER_NAME: mysql
-          PORT_MAPPING: 3306:3306
-          ROOT_PASSWORD: seata_go
-          DATABASE: seata_go_test
-
+          host port: 3306 # Optional, default value is 3306. The port of host
+          container port: 3306 # Optional, default value is 3306. The port of container
+          mysql version: '8.0' # Optional, default value is "latest". The version of the MySQL
+          mysql database: 'seata_go_test' # Optional, default value is "test". The specified database which will be create
+          mysql root password: 'seata_go' # Required if "mysql user" is empty, default is empty. The root superuser password
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: "checkout ${{ github.ref }}"
         uses: actions/checkout@v3


### PR DESCRIPTION
**What this PR does**:
CI Error: Unable to resolve action icomponent/mysql-action, repository not found.
use mirromutth/mysql-action instead of icomponent/mysql-action.
