### PR TITLE
chore: unnecessary use of fmt.Sprintf

### DIFF
--- a/pkg/tm/transaction_executor_test.go
+++ b/pkg/tm/transaction_executor_test.go
@@ -19,7 +19,6 @@ package tm
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -114,7 +113,7 @@ func TestTransactionExecutorBegin(t *testing.T) {
 			},
 			xid:             "123456",
 			wantHasError:    true,
-			wantErrorString: fmt.Sprintf("existing transaction found for transaction marked with pg 'never', xid = 123456"),
+			wantErrorString: "existing transaction found for transaction marked with pg 'never', xid = 123456",
 		},
 		// has not error
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
remove unnecessary use of fmt.Sprintf
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```