### PR TITLE
clean unused datasource config

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -69,13 +69,11 @@ func (c *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 }
 
 type Config struct {
-	Enabled                   bool   `yaml:"enabled" json:"enabled,omitempty" koanf:"enabled"`
-	ApplicationID             string `yaml:"application-id" json:"application-id,omitempty" koanf:"application-id"`
-	TxServiceGroup            string `yaml:"tx-service-group" json:"tx-service-group,omitempty" koanf:"tx-service-group"`
-	AccessKey                 string `yaml:"access-key" json:"access-key,omitempty" koanf:"access-key"`
-	SecretKey                 string `yaml:"secret-key" json:"secret-key,omitempty" koanf:"secret-key"`
-	EnableAutoDataSourceProxy bool   `yaml:"enable-auto-data-source-proxy" json:"enable-auto-data-source-proxy,omitempty" koanf:"enable-auto-data-source-proxy"`
-	DataSourceProxyMode       string `yaml:"data-source-proxy-mode" json:"data-source-proxy-mode,omitempty" koanf:"data-source-proxy-mode"`
+	Enabled        bool   `yaml:"enabled" json:"enabled,omitempty" koanf:"enabled"`
+	ApplicationID  string `yaml:"application-id" json:"application-id,omitempty" koanf:"application-id"`
+	TxServiceGroup string `yaml:"tx-service-group" json:"tx-service-group,omitempty" koanf:"tx-service-group"`
+	AccessKey      string `yaml:"access-key" json:"access-key,omitempty" koanf:"access-key"`
+	SecretKey      string `yaml:"secret-key" json:"secret-key,omitempty" koanf:"secret-key"`
 
 	AsyncWorkerConfig sql.AsyncWorkerConfig        `yaml:"async" json:"async" koanf:"async"`
 	TCCConfig         tcc.Config                   `yaml:"tcc" json:"tcc" koanf:"tcc"`
@@ -92,8 +90,6 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.TxServiceGroup, "tx-service-group", "default_tx_group", "Transaction service group.")
 	f.StringVar(&c.AccessKey, "access-key", "", "Used for aliyun accessKey.")
 	f.StringVar(&c.SecretKey, "secret-key", "", "Used for aliyun secretKey.")
-	f.BoolVar(&c.EnableAutoDataSourceProxy, "enable-auto-data-source-proxy", true, "Whether enable auto proxying of datasource bean.")
-	f.StringVar(&c.DataSourceProxyMode, "data-source-proxy-mode", "AT", "Data source proxy mode.")
 
 	c.AsyncWorkerConfig.RegisterFlagsWithPrefix("async-worker", f)
 	c.TCCConfig.RegisterFlagsWithPrefix("tcc", f)

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -34,8 +34,6 @@ func TestLoadPath(t *testing.T) {
 	assert.Equal(t, "default_tx_group", cfg.TxServiceGroup)
 	assert.Equal(t, "aliyunAccessKey", cfg.AccessKey)
 	assert.Equal(t, "aliyunSecretKey", cfg.SecretKey)
-	assert.Equal(t, true, cfg.EnableAutoDataSourceProxy)
-	assert.Equal(t, "AT", cfg.DataSourceProxyMode)
 
 	assert.NotNil(t, cfg.TCCConfig)
 	assert.NotNil(t, cfg.TCCConfig.FenceConfig)
@@ -131,7 +129,7 @@ func TestLoadPath(t *testing.T) {
 }
 
 func TestLoadJson(t *testing.T) {
-	confJson := `{"enabled":false,"application-id":"application_test","tx-service-group":"default_tx_group","access-key":"test","secret-key":"test","enable-auto-data-source-proxy":false,"data-source-proxy-mode":"AT","client":{"rm":{"async-commit-buffer-limit":10000,"report-retry-count":5,"table-meta-check-enable":false,"report-success-enable":false,"saga-branch-register-enable":false,"saga-json-parser":"fastjson","saga-retry-persist-mode-update":false,"saga-compensate-persist-mode-update":false,"tcc-action-interceptor-order":-2147482648,"sql-parser-type":"druid","lock":{"retry-interval":"30s","retry-times":10,"retry-policy-branch-rollback-on-conflict":true}},"tm":{"commit-retry-count":5,"rollback-retry-count":5,"default-global-transaction-timeout":"60s","degrade-check":false,"degrade-check-period":2000,"degrade-check-allow-times":"10s","interceptor-order":-2147482648},"undo":{"data-validation":false,"log-serialization":"jackson222","only-care-update-columns":false,"log-table":"undo_log333","compress":{"enable":false,"type":"zip111","threshold":"128k"}}},"tcc":{"fence":{"log-table-name":"tcc_fence_log_test2","clean-period":80000000000}},"getty":{"reconnect-interval":1,"connection-num":10,"session":{"compress-encoding":true,"tcp-no-delay":false,"tcp-keep-alive":false,"keep-alive-period":"120s","tcp-r-buf-size":261120,"tcp-w-buf-size":32768,"tcp-read-timeout":"2s","tcp-write-timeout":"8s","wait-timeout":"2s","max-msg-len":261120,"session-name":"client_test","cron-period":"2s"}},"transport":{"shutdown":{"wait":"3s"},"type":"TCP","server":"NIO","heartbeat":true,"serialization":"seata","compressor":"none"," enable-tm-client-batch-send-request":false,"enable-rm-client-batch-send-request":true,"rpc-rm-request-timeout":"30s","rpc-tm-request-timeout":"30s"},"service":{"enable-degrade":true,"disable-global-transaction":true,"vgroup-mapping":{"default_tx_group":"default_test"},"grouplist":{"default":"127.0.0.1:8092"}}}`
+	confJson := `{"enabled":false,"application-id":"application_test","tx-service-group":"default_tx_group","access-key":"test","secret-key":"test","client":{"rm":{"async-commit-buffer-limit":10000,"report-retry-count":5,"table-meta-check-enable":false,"report-success-enable":false,"saga-branch-register-enable":false,"saga-json-parser":"fastjson","saga-retry-persist-mode-update":false,"saga-compensate-persist-mode-update":false,"tcc-action-interceptor-order":-2147482648,"sql-parser-type":"druid","lock":{"retry-interval":"30s","retry-times":10,"retry-policy-branch-rollback-on-conflict":true}},"tm":{"commit-retry-count":5,"rollback-retry-count":5,"default-global-transaction-timeout":"60s","degrade-check":false,"degrade-check-period":2000,"degrade-check-allow-times":"10s","interceptor-order":-2147482648},"undo":{"data-validation":false,"log-serialization":"jackson222","only-care-update-columns":false,"log-table":"undo_log333","compress":{"enable":false,"type":"zip111","threshold":"128k"}}},"tcc":{"fence":{"log-table-name":"tcc_fence_log_test2","clean-period":80000000000}},"getty":{"reconnect-interval":1,"connection-num":10,"session":{"compress-encoding":true,"tcp-no-delay":false,"tcp-keep-alive":false,"keep-alive-period":"120s","tcp-r-buf-size":261120,"tcp-w-buf-size":32768,"tcp-read-timeout":"2s","tcp-write-timeout":"8s","wait-timeout":"2s","max-msg-len":261120,"session-name":"client_test","cron-period":"2s"}},"transport":{"shutdown":{"wait":"3s"},"type":"TCP","server":"NIO","heartbeat":true,"serialization":"seata","compressor":"none"," enable-tm-client-batch-send-request":false,"enable-rm-client-batch-send-request":true,"rpc-rm-request-timeout":"30s","rpc-tm-request-timeout":"30s"},"service":{"enable-degrade":true,"disable-global-transaction":true,"vgroup-mapping":{"default_tx_group":"default_test"},"grouplist":{"default":"127.0.0.1:8092"}}}`
 	cfg := LoadJson([]byte(confJson))
 	assert.NotNil(t, cfg)
 	assert.Equal(t, false, cfg.Enabled)
@@ -139,8 +137,6 @@ func TestLoadJson(t *testing.T) {
 	assert.Equal(t, "default_tx_group", cfg.TxServiceGroup)
 	assert.Equal(t, "test", cfg.AccessKey)
 	assert.Equal(t, "test", cfg.SecretKey)
-	assert.Equal(t, false, cfg.EnableAutoDataSourceProxy)
-	assert.Equal(t, "AT", cfg.DataSourceProxyMode)
 
 	assert.Equal(t, 10000, cfg.ClientConfig.RmConfig.AsyncCommitBufferLimit)
 	assert.Equal(t, 5, cfg.ClientConfig.RmConfig.ReportRetryCount)

--- a/testdata/conf/seatago.yml
+++ b/testdata/conf/seatago.yml
@@ -22,8 +22,6 @@ seata:
   tx-service-group: default_tx_group
   access-key: aliyunAccessKey
   secret-key: aliyunSecretKey
-  enable-auto-data-source-proxy: true
-  data-source-proxy-mode: AT
   client:
     rm:
       # Maximum cache length of asynchronous queue
@@ -131,8 +129,8 @@ seata:
       username: "test-username"
       password: "test-password"
       ##if use MSE Nacos with auth, mutex with username/password attribute  #
-      access-key: "test-access-key"  #
-      secret-key: "test-secret-key"  #
+      access-key: "test-access-key" #
+      secret-key: "test-secret-key" #
     etcd3:
       cluster: "default"
       server-addr: "http://localhost:2379"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Clean unused datasource config. Developer is able to pick AT/XA DB driver when open a database, [like this](https://github.com/apache/incubator-seata-go-samples/blob/main/util/db.go)

```
dbAt, err := sql.Open(sql2.SeataATMySQLDriver, dsn)
dbAt, err := sql.Open(sql2.SeataXAMySQLDriver, dsn)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```