### PR TITLE
handle concurrent timeout close conn

### DIFF
--- a/pkg/datasource/sql/conn_xa.go
+++ b/pkg/datasource/sql/conn_xa.go
@@ -202,9 +202,9 @@ func (c *XAConn) createNewTxOnExecIfNeed(ctx context.Context, f func() (types.Ex
 
 	// When c.xaActive is false, i.e, when cleanXABranchContext() has been called, it means
 	// this xa transaction has been terminated(db conn closed)/rollbacked/commited). No need to proceed anymore.
-	// This could be introduced by a timeout check located at
+	// This could be introduced by a concurrent timeout check located at
 	// pkg/database/sql/xa_resource_manager.go, xaTwoPhaseTimeoutChecker() and
-	// probably other similar scenarios.
+	// probably other similar async scenarios.
 	if !c.xaActive {
 		return nil, fmt.Errorf("xa tx has been terminated due to xaActive being false")
 	}

--- a/pkg/datasource/sql/conn_xa.go
+++ b/pkg/datasource/sql/conn_xa.go
@@ -201,7 +201,7 @@ func (c *XAConn) createNewTxOnExecIfNeed(ctx context.Context, f func() (types.Ex
 	ret, err := f()
 
 	// When c.xaActive is false, i.e, when cleanXABranchContext() has been called, it means
-	// this xa transaction has been terminated(db conn closed)/rollbacked/commited). No need to proceed anymore.
+	// this xa transaction has been terminated(db conn closed)/rollbacked/committed). No need to proceed anymore.
 	// This could be introduced by a concurrent timeout check located at
 	// pkg/database/sql/xa_resource_manager.go, xaTwoPhaseTimeoutChecker() and
 	// probably other similar async scenarios.
@@ -395,7 +395,7 @@ func (c *XAConn) CloseForce() error {
 }
 
 func (c *XAConn) XaCommit(ctx context.Context, xaXid XAXid) error {
-	// xa tx has been either terminated(db conn closed)/rollbacked/commited already
+	// xa tx has been either terminated(db conn closed)/rollbacked/committed already
 	if !c.xaActive {
 		return nil
 	}
@@ -405,7 +405,7 @@ func (c *XAConn) XaCommit(ctx context.Context, xaXid XAXid) error {
 }
 
 func (c *XAConn) XaRollbackByBranchId(ctx context.Context, xaXid XAXid) error {
-	// xa tx has been either terminated(db conn closed)/rollbacked/commited already
+	// xa tx has been either terminated(db conn closed)/rollbacked/committed already
 	if !c.xaActive {
 		return nil
 	}
@@ -413,7 +413,7 @@ func (c *XAConn) XaRollbackByBranchId(ctx context.Context, xaXid XAXid) error {
 }
 
 func (c *XAConn) XaRollback(ctx context.Context, xaXid XAXid) error {
-	// xa tx has been either terminated(db conn closed)/rollbacked/commited already
+	// xa tx has been either terminated(db conn closed)/rollbacked/committed already
 	if !c.xaActive {
 		return nil
 	}

--- a/pkg/datasource/sql/conn_xa.go
+++ b/pkg/datasource/sql/conn_xa.go
@@ -199,6 +199,16 @@ func (c *XAConn) createNewTxOnExecIfNeed(ctx context.Context, f func() (types.Ex
 
 	// execute SQL
 	ret, err := f()
+
+	// When c.xaActive is false, i.e, when cleanXABranchContext() has been called, it means
+	// this xa transaction has been terminated(db conn closed)/rollbacked/commited). No need to proceed anymore.
+	// This could be introduced by a timeout check located at
+	// pkg/database/sql/xa_resource_manager.go, xaTwoPhaseTimeoutChecker() and
+	// probably other similar scenarios.
+	if !c.xaActive {
+		return nil, fmt.Errorf("xa tx has been terminated due to xaActive being false")
+	}
+
 	if err != nil {
 		// XA End & Rollback
 		if rollbackErr := c.Rollback(ctx); rollbackErr != nil {
@@ -385,16 +395,28 @@ func (c *XAConn) CloseForce() error {
 }
 
 func (c *XAConn) XaCommit(ctx context.Context, xaXid XAXid) error {
+	// xa tx has been either terminated(db conn closed)/rollbacked/commited already
+	if !c.xaActive {
+		return nil
+	}
 	err := c.xaResource.Commit(ctx, xaXid.String(), false)
 	c.releaseIfNecessary()
 	return err
 }
 
 func (c *XAConn) XaRollbackByBranchId(ctx context.Context, xaXid XAXid) error {
+	// xa tx has been either terminated(db conn closed)/rollbacked/commited already
+	if !c.xaActive {
+		return nil
+	}
 	return c.XaRollback(ctx, xaXid)
 }
 
 func (c *XAConn) XaRollback(ctx context.Context, xaXid XAXid) error {
+	// xa tx has been either terminated(db conn closed)/rollbacked/commited already
+	if !c.xaActive {
+		return nil
+	}
 	err := c.xaResource.Rollback(ctx, xaXid.String())
 	c.releaseIfNecessary()
 	return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

`pkg/database/sql/xa_resource_manager.go, xaTwoPhaseTimeoutChecker()` 在xa 二阶段timeout时，(默认是1秒，https://github.com/apache/incubator-seata-go/blob/master/pkg/datasource/sql/xa_resource_manager.go#L54)， 会强制关闭本地数据库conn https://github.com/apache/incubator-seata-go/blob/master/pkg/datasource/sql/xa_resource_manager.go#L105。比如我们的业务逻辑sql，执行时间超过了1秒（xa 二阶段timeout 时间）。 而原来的流程不会因为conn 已经被关闭了，就做出相应响应。而是不断地尝试Commit (正常业务逻辑sql执行完，就需要xa commit， https://github.com/apache/incubator-seata-go/blob/master/pkg/datasource/sql/conn_xa.go#L211)， 然后因为commit 失败，不断尝试 Rollback。

但是此时因为原来的db conn 已经完全关闭了, https://github.com/apache/incubator-seata-go/blob/master/pkg/datasource/sql/conn_xa.go#L378，本地RM的xa 事务已经完全丢失了，xid也在数据库里找不到了，此时就不停地报错 `XAER_NOTA: Unknown XID`.

这个PR，在每次XA commit/rollback 前，检测下xa 状态是否还是活跃状态，在业务逻辑sql执行完成后，也检测下当前xa 状态是否还是活跃状态。

如果不是活跃状态，表示这里的db conn已经close了，或是xa tx可能已经在其他异步goroutine里 commit，或是 rollback了。那在上面的场景下，立即返回，不会重复做commit跟rollback的无用功。

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #676

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```