### PR TITLE
fix: fix ci-lint typecheck error

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -39,14 +39,14 @@ jobs:
     strategy:
       matrix:
         golang:
-          - 1.18
+          - 1.20.0
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: "set up go"
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20.0
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: "checkout ${{ github.ref }}"
@@ -55,6 +55,6 @@ jobs:
       - name: "golang ci lint"
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.49.0
+          version: v1.51.0
           args: --timeout=10m
           skip-go-installation: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**: This PR upgrades the golangci-lint from version 1.49.0 to 1.51.0 to fix it's typecheck error

**Which issue(s) this PR fixes**:  #770 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```