### PR TITLE
fix: failed to decode ColumnImage mysql:text type by json

### DIFF
--- a/pkg/datasource/sql/types/image.go
+++ b/pkg/datasource/sql/types/image.go
@@ -251,7 +251,7 @@ func (c *ColumnImage) UnmarshalJSON(data []byte) error {
 			if err != nil {
 				return err
 			}
-		case JDBCTypeChar, JDBCTypeVarchar:
+		case JDBCTypeChar, JDBCTypeVarchar, JDBCTypeLongVarchar:
 			var val []byte
 			if val, err = base64.StdEncoding.DecodeString(value.(string)); err != nil {
 				val = []byte(value.(string))

--- a/pkg/datasource/sql/types/image_test.go
+++ b/pkg/datasource/sql/types/image_test.go
@@ -43,6 +43,16 @@ func TestColumnImage_UnmarshalJSON(t *testing.T) {
 			expectValue: "Seata-go",
 		},
 		{
+			name: "test-text",
+			image: &ColumnImage{
+				KeyType:    IndexTypePrimaryKey,
+				ColumnName: "Text",
+				ColumnType: JDBCTypeLongVarchar,
+				Value:      []byte("Seata-go"),
+			},
+			expectValue: "Seata-go",
+		},
+		{
 			name: "test-int",
 			image: &ColumnImage{
 				KeyType:    IndexTypeNull,


### PR DESCRIPTION
When deserializing the `ColumnImage`, when the type of the column in mysql is text, and when the type of the column in seata-go is `JDBCTypeLongVarchar`, there is no handling in the code

https://github.com/apache/incubator-seata-go/blob/8d9f809242c4a1bcb759e4759e137b224f4ef53b/pkg/datasource/sql/types/image.go#L207