### PR TITLE
refactor: update SHA256 checksum command in makefile for cross-platfo…

### DIFF
--- a/makefile
+++ b/makefile
@@ -24,6 +24,11 @@ GO_OS = $(shell $(GO) env GOOS)
 ifeq ($(GO_OS), darwin)
     GO_OS = mac
 endif
+ifeq ($(shell uname -s), Darwin)
+    SHA256_CMD = shasum -a 256
+else
+    SHA256_CMD = sha256sum
+endif
 
 # License environment
 GO_LICENSE_CHECKER_DIR = license-header-checker-$(GO_OS)
@@ -44,15 +49,15 @@ dist dist/seatago-linux-amd64 dist/seatago-darwin-amd64 dist/seatago-linux-amd64
 	mkdir -p ./dist
 	GOOS="linux"  GOARCH="amd64" CGO_ENABLED=0 go build $(GO_FLAGS) -o ./dist/seatago-linux-amd64 ./cmd
 	GOOS="darwin" GOARCH="amd64" CGO_ENABLED=0 go build $(GO_FLAGS) -o ./dist/seatago-darwin-amd64 ./cmd
-	sha256sum ./dist/seatago-darwin-amd64 | cut -d ' ' -f 1 > ./dist/seatago-darwin-amd64-sha-256
-	sha256sum ./dist/seatago-linux-amd64  | cut -d ' ' -f 1 > ./dist/seatago-linux-amd64-sha-256
+	$(SHA256_CMD) ./dist/seatago-darwin-amd64 | cut -d ' ' -f 1 > ./dist/seatago-darwin-amd64-sha-256
+	$(SHA256_CMD) ./dist/seatago-linux-amd64  | cut -d ' ' -f 1 > ./dist/seatago-linux-amd64-sha-256
 
 # Generate binaries for a Cortex release
 build dist/seatago dist/seatago-sha-256:
 	rm -fr ./dist
 	mkdir -p ./dist
 	CGO_ENABLED=0 go build $(GO_FLAGS) -o ./dist/seatago ./cmd
-	sha256sum ./dist/seatago  | cut -d ' ' -f 1 > ./dist/seatago-sha-256
+	$(SHA256_CMD) ./dist/seatago  | cut -d ' ' -f 1 > ./dist/seatago-sha-256
 
 #docker-build:
 #	docker build -t seatago/seatago:latest .


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

This PR simplifies the dependencies of the `make build` command in the makefile by implementing cross-platform SHA-256 checksum support. It replaces hardcoded `sha256sum` commands with dynamic command detection that uses:
- `shasum -a 256` on macOS (Darwin) systems  
- `sha256sum` on Linux/Unix systems

This ensures the makefile can run with minimal dependencies across different operating systems without requiring additional tool installations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #819: Simplify makefile dependencies with cross-platform SHA-256 compatibility

**Special notes for your reviewer**:

- Tested on both M2 Mac (macOS) and WSL (Linux) environments - both work correctly

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```