### PR TITLE
Optimize/at build lock key performance 

### DIFF
--- a/pkg/datasource/sql/exec/at/base_executor.go
+++ b/pkg/datasource/sql/exec/at/base_executor.go
@@ -358,48 +358,5 @@ func (b *baseExecutor) buildPKParams(rows []types.RowImage, pkNameList []string)
 
 // the string as local key. the local key example(multi pk): "t_user:1_a,2_b"
 func (b *baseExecutor) buildLockKey(records *types.RecordImage, meta types.TableMeta) string {
-	var lockKeys strings.Builder
-	type ColMapItem struct {
-		pkIndex  int
-		colIndex int
-	}
-
-	lockKeys.WriteString(meta.TableName)
-	lockKeys.WriteString(":")
-
-	keys := meta.GetPrimaryKeyOnlyName()
-	keyIndexMap := make(map[string]int, len(keys))
-	for idx, columnName := range keys {
-		keyIndexMap[columnName] = idx
-	}
-
-	columns := make([]ColMapItem, 0, len(keys))
-	if len(records.Rows) > 0 {
-		for colIdx, column := range records.Rows[0].Columns {
-			if pkIdx, ok := keyIndexMap[column.ColumnName]; ok {
-				columns = append(columns, ColMapItem{pkIndex: pkIdx, colIndex: colIdx})
-			}
-		}
-		for i, row := range records.Rows {
-			if i > 0 {
-				lockKeys.WriteString(",")
-			}
-			primaryKeyValues := make([]interface{}, len(keys))
-			for _, mp := range columns {
-				if mp.colIndex < len(row.Columns) {
-					primaryKeyValues[mp.pkIndex] = row.Columns[mp.colIndex].Value
-				}
-			}
-			for j, pkVal := range primaryKeyValues {
-				if j > 0 {
-					lockKeys.WriteString("_")
-				}
-				if pkVal == nil {
-					continue
-				}
-				lockKeys.WriteString(fmt.Sprintf("%v", pkVal))
-			}
-		}
-	}
-	return lockKeys.String()
+	return util.BuildLockKey(records, meta)
 }

--- a/pkg/datasource/sql/exec/at/base_executor.go
+++ b/pkg/datasource/sql/exec/at/base_executor.go
@@ -22,9 +22,8 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"strings"
-
 	"seata.apache.org/seata-go/pkg/datasource/sql/undo"
+	"strings"
 
 	"github.com/arana-db/parser/ast"
 	"github.com/arana-db/parser/test_driver"

--- a/pkg/datasource/sql/exec/at/base_executor_test.go
+++ b/pkg/datasource/sql/exec/at/base_executor_test.go
@@ -43,6 +43,7 @@ func TestBaseExecBuildLockKey(t *testing.T) {
 	}
 
 	columnsTwoPk := []types.ColumnMeta{columnID, columnUserId}
+	columnsThreePk := []types.ColumnMeta{columnID, columnUserId, columnAge}
 	columnsMixPk := []types.ColumnMeta{columnName, columnAge}
 
 	getColumnImage := func(columnName string, value interface{}) types.ColumnImage {
@@ -71,6 +72,24 @@ func TestBaseExecBuildLockKey(t *testing.T) {
 				},
 			},
 			"test_name:1_user1,2_user2",
+		},
+		{
+			"Three Primary Keys",
+			types.TableMeta{
+				TableName: "test2_name",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: columnsThreePk},
+				},
+			},
+			types.RecordImage{
+				TableName: "test2_name",
+				Rows: []types.RowImage{
+					{[]types.ColumnImage{getColumnImage("id", 1), getColumnImage("userId", "one"), getColumnImage("age", "11")}},
+					{[]types.ColumnImage{getColumnImage("id", 2), getColumnImage("userId", "two"), getColumnImage("age", "22")}},
+					{[]types.ColumnImage{getColumnImage("id", 3), getColumnImage("userId", "three"), getColumnImage("age", "33")}},
+				},
+			},
+			"test2_name:1_one_11,2_two_22,3_three_33",
 		},
 		{
 			name: "Single Primary Key",

--- a/pkg/datasource/sql/exec/at/base_executor_test.go
+++ b/pkg/datasource/sql/exec/at/base_executor_test.go
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package at
+
+import (
+	"github.com/stretchr/testify/assert"
+	"seata.apache.org/seata-go/pkg/datasource/sql/types"
+	"testing"
+)
+
+func TestBaseExecBuildLockKey(t *testing.T) {
+	var exec baseExecutor
+
+	columnID := types.ColumnMeta{
+		ColumnName: "id",
+	}
+	columnUserId := types.ColumnMeta{
+		ColumnName: "userId",
+	}
+	columnName := types.ColumnMeta{
+		ColumnName: "name",
+	}
+	columnAge := types.ColumnMeta{
+		ColumnName: "age",
+	}
+	columnNonExistent := types.ColumnMeta{
+		ColumnName: "non_existent",
+	}
+
+	columnsTwoPk := []types.ColumnMeta{columnID, columnUserId}
+	columnsMixPk := []types.ColumnMeta{columnName, columnAge}
+
+	getColumnImage := func(columnName string, value interface{}) types.ColumnImage {
+		return types.ColumnImage{KeyType: types.IndexTypePrimaryKey, ColumnName: columnName, Value: value}
+	}
+
+	tests := []struct {
+		name     string
+		metaData types.TableMeta
+		records  types.RecordImage
+		expected string
+	}{
+		{
+			"Two Primary Keys",
+			types.TableMeta{
+				TableName: "test_name",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: columnsTwoPk},
+				},
+			},
+			types.RecordImage{
+				TableName: "test_name",
+				Rows: []types.RowImage{
+					{[]types.ColumnImage{getColumnImage("id", 1), getColumnImage("userId", "user1")}},
+					{[]types.ColumnImage{getColumnImage("id", 2), getColumnImage("userId", "user2")}},
+				},
+			},
+			"test_name:1_user1,2_user2",
+		},
+		{
+			name: "Single Primary Key",
+			metaData: types.TableMeta{
+				TableName: "single_key",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: []types.ColumnMeta{columnID}},
+				},
+			},
+			records: types.RecordImage{
+				TableName: "single_key",
+				Rows: []types.RowImage{
+					{Columns: []types.ColumnImage{getColumnImage("id", 100)}},
+				},
+			},
+			expected: "single_key:100",
+		},
+		{
+			name: "Mixed Type Keys",
+			metaData: types.TableMeta{
+				TableName: "mixed_key",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: columnsMixPk},
+				},
+			},
+			records: types.RecordImage{
+				TableName: "mixed_key",
+				Rows: []types.RowImage{
+					{Columns: []types.ColumnImage{getColumnImage("name", "mike"), getColumnImage("age", 25)}},
+				},
+			},
+			expected: "mixed_key:mike_25",
+		},
+		{
+			name: "Empty Records",
+			metaData: types.TableMeta{
+				TableName: "empty",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: []types.ColumnMeta{columnID}},
+				},
+			},
+			records:  types.RecordImage{TableName: "empty"},
+			expected: "empty:",
+		},
+		{
+			name: "Special Characters",
+			metaData: types.TableMeta{
+				TableName: "special",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: []types.ColumnMeta{columnID}},
+				},
+			},
+			records: types.RecordImage{
+				TableName: "special",
+				Rows: []types.RowImage{
+					{Columns: []types.ColumnImage{getColumnImage("id", "A,b_c")}},
+				},
+			},
+			expected: "special:A,b_c",
+		},
+		{
+			name: "Non-existent Key Name",
+			metaData: types.TableMeta{
+				TableName: "error_key",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: []types.ColumnMeta{columnNonExistent}},
+				},
+			},
+			records: types.RecordImage{
+				TableName: "error_key",
+				Rows: []types.RowImage{
+					{Columns: []types.ColumnImage{getColumnImage("id", 1)}},
+				},
+			},
+			expected: "error_key:",
+		},
+		{
+			name: "Multiple Rows With Nil PK Value",
+			metaData: types.TableMeta{
+				TableName: "nil_pk",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: []types.ColumnMeta{columnID}},
+				},
+			},
+			records: types.RecordImage{
+				TableName: "nil_pk",
+				Rows: []types.RowImage{
+					{Columns: []types.ColumnImage{getColumnImage("id", nil)}},
+					{Columns: []types.ColumnImage{getColumnImage("id", 123)}},
+					{Columns: []types.ColumnImage{getColumnImage("id", nil)}},
+				},
+			},
+			expected: "nil_pk:,123,",
+		},
+		{
+			name: "PK As Bool And Float",
+			metaData: types.TableMeta{
+				TableName: "type_pk",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: []types.ColumnMeta{columnName, columnAge}},
+				},
+			},
+			records: types.RecordImage{
+				TableName: "type_pk",
+				Rows: []types.RowImage{
+					{Columns: []types.ColumnImage{getColumnImage("name", true), getColumnImage("age", 3.14)}},
+					{Columns: []types.ColumnImage{getColumnImage("name", false), getColumnImage("age", 0.0)}},
+				},
+			},
+			expected: "type_pk:true_3.14,false_0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lockKeys := exec.buildLockKey(&tt.records, tt.metaData)
+			assert.Equal(t, tt.expected, lockKeys)
+		})
+	}
+}

--- a/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
+++ b/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
@@ -277,42 +277,47 @@ func (b *BasicUndoLogBuilder) buildLockKey(rows driver.Rows, meta types.TableMet
 // the string as local key. the local key example(multi pk): "t_user:1_a,2_b"
 func (b *BasicUndoLogBuilder) buildLockKey2(records *types.RecordImage, meta types.TableMeta) string {
 	var lockKeys strings.Builder
+	type ColMapItem struct {
+		pkIndex  int
+		colIndex int
+	}
+
 	lockKeys.WriteString(meta.TableName)
 	lockKeys.WriteString(":")
 
 	keys := meta.GetPrimaryKeyOnlyName()
 	keyIndexMap := make(map[string]int, len(keys))
-
 	for idx, columnName := range keys {
 		keyIndexMap[columnName] = idx
 	}
 
-	primaryKeyRows := make([][]interface{}, len(records.Rows))
-
-	for i, row := range records.Rows {
-		primaryKeyValues := make([]interface{}, len(keys))
-		for _, column := range row.Columns {
-			if idx, exist := keyIndexMap[column.ColumnName]; exist {
-				primaryKeyValues[idx] = column.Value
+	columns := make([]ColMapItem, 0, len(keys))
+	if len(records.Rows) > 0 {
+		for colIdx, column := range records.Rows[0].Columns {
+			if pkIdx, ok := keyIndexMap[column.ColumnName]; ok {
+				columns = append(columns, ColMapItem{pkIndex: pkIdx, colIndex: colIdx})
 			}
 		}
-		primaryKeyRows[i] = primaryKeyValues
+		for i, row := range records.Rows {
+			if i > 0 {
+				lockKeys.WriteString(",")
+			}
+			primaryKeyValues := make([]interface{}, len(keys))
+			for _, mp := range columns {
+				if mp.colIndex < len(row.Columns) {
+					primaryKeyValues[mp.pkIndex] = row.Columns[mp.colIndex].Value
+				}
+			}
+			for j, pkVal := range primaryKeyValues {
+				if j > 0 {
+					lockKeys.WriteString("_")
+				}
+				if pkVal == nil {
+					continue
+				}
+				lockKeys.WriteString(fmt.Sprintf("%v", pkVal))
+			}
+		}
 	}
-
-	for i, primaryKeyValues := range primaryKeyRows {
-		if i > 0 {
-			lockKeys.WriteString(",")
-		}
-		for j, pkVal := range primaryKeyValues {
-			if j > 0 {
-				lockKeys.WriteString("_")
-			}
-			if pkVal == nil {
-				continue
-			}
-			lockKeys.WriteString(fmt.Sprintf("%v", pkVal))
-		}
-	}
-
 	return lockKeys.String()
 }

--- a/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
+++ b/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
@@ -26,6 +26,7 @@ import (
 	"github.com/arana-db/parser/test_driver"
 	gxsort "github.com/dubbogo/gost/sort"
 	"io"
+	"seata.apache.org/seata-go/pkg/datasource/sql/util"
 	"strings"
 
 	"seata.apache.org/seata-go/pkg/datasource/sql/types"
@@ -275,48 +276,5 @@ func (b *BasicUndoLogBuilder) buildLockKey(rows driver.Rows, meta types.TableMet
 
 // the string as local key. the local key example(multi pk): "t_user:1_a,2_b"
 func (b *BasicUndoLogBuilder) buildLockKey2(records *types.RecordImage, meta types.TableMeta) string {
-	var lockKeys strings.Builder
-	type ColMapItem struct {
-		pkIndex  int
-		colIndex int
-	}
-
-	lockKeys.WriteString(meta.TableName)
-	lockKeys.WriteString(":")
-
-	keys := meta.GetPrimaryKeyOnlyName()
-	keyIndexMap := make(map[string]int, len(keys))
-	for idx, columnName := range keys {
-		keyIndexMap[columnName] = idx
-	}
-
-	columns := make([]ColMapItem, 0, len(keys))
-	if len(records.Rows) > 0 {
-		for colIdx, column := range records.Rows[0].Columns {
-			if pkIdx, ok := keyIndexMap[column.ColumnName]; ok {
-				columns = append(columns, ColMapItem{pkIndex: pkIdx, colIndex: colIdx})
-			}
-		}
-		for i, row := range records.Rows {
-			if i > 0 {
-				lockKeys.WriteString(",")
-			}
-			primaryKeyValues := make([]interface{}, len(keys))
-			for _, mp := range columns {
-				if mp.colIndex < len(row.Columns) {
-					primaryKeyValues[mp.pkIndex] = row.Columns[mp.colIndex].Value
-				}
-			}
-			for j, pkVal := range primaryKeyValues {
-				if j > 0 {
-					lockKeys.WriteString("_")
-				}
-				if pkVal == nil {
-					continue
-				}
-				lockKeys.WriteString(fmt.Sprintf("%v", pkVal))
-			}
-		}
-	}
-	return lockKeys.String()
+	return util.BuildLockKey(records, meta)
 }

--- a/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
+++ b/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
@@ -22,12 +22,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"io"
-	"strings"
-
 	"github.com/arana-db/parser/ast"
 	"github.com/arana-db/parser/test_driver"
 	gxsort "github.com/dubbogo/gost/sort"
+	"io"
+	"strings"
 
 	"seata.apache.org/seata-go/pkg/datasource/sql/types"
 )

--- a/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
+++ b/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
@@ -276,7 +276,7 @@ func (b *BasicUndoLogBuilder) buildLockKey(rows driver.Rows, meta types.TableMet
 
 // the string as local key. the local key example(multi pk): "t_user:1_a,2_b"
 func (b *BasicUndoLogBuilder) buildLockKey2(records *types.RecordImage, meta types.TableMeta) string {
-	var lockKeys bytes.Buffer
+	var lockKeys strings.Builder
 	lockKeys.WriteString(meta.TableName)
 	lockKeys.WriteString(":")
 

--- a/pkg/datasource/sql/undo/builder/basic_undo_log_builder_test.go
+++ b/pkg/datasource/sql/undo/builder/basic_undo_log_builder_test.go
@@ -69,6 +69,7 @@ func TestBuildLockKey(t *testing.T) {
 	}
 
 	columnsTwoPk := []types.ColumnMeta{columnID, columnUserId}
+	columnsThreePk := []types.ColumnMeta{columnID, columnUserId, columnAge}
 	columnsMixPk := []types.ColumnMeta{columnName, columnAge}
 
 	getColumnImage := func(columnName string, value interface{}) types.ColumnImage {
@@ -97,6 +98,24 @@ func TestBuildLockKey(t *testing.T) {
 				},
 			},
 			"test_name:1_one,2_two",
+		},
+		{
+			"Three Primary Keys",
+			types.TableMeta{
+				TableName: "test2_name",
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY_KEY": {IType: types.IndexTypePrimaryKey, Columns: columnsThreePk},
+				},
+			},
+			types.RecordImage{
+				TableName: "test2_name",
+				Rows: []types.RowImage{
+					{[]types.ColumnImage{getColumnImage("id", 1), getColumnImage("userId", "one"), getColumnImage("age", "11")}},
+					{[]types.ColumnImage{getColumnImage("id", 2), getColumnImage("userId", "two"), getColumnImage("age", "22")}},
+					{[]types.ColumnImage{getColumnImage("id", 3), getColumnImage("userId", "three"), getColumnImage("age", "33")}},
+				},
+			},
+			"test2_name:1_one_11,2_two_22,3_three_33",
 		},
 		{
 			name: "Single Primary Key",

--- a/pkg/datasource/sql/util/lockkey.go
+++ b/pkg/datasource/sql/util/lockkey.go
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"fmt"
+	"seata.apache.org/seata-go/pkg/datasource/sql/types"
+	"strings"
+)
+
+func BuildLockKey(records *types.RecordImage, meta types.TableMeta) string {
+	var lockKeys strings.Builder
+	type ColMapItem struct {
+		pkIndex  int
+		colIndex int
+	}
+
+	lockKeys.WriteString(meta.TableName)
+	lockKeys.WriteString(":")
+
+	keys := meta.GetPrimaryKeyOnlyName()
+	keyIndexMap := make(map[string]int, len(keys))
+	for idx, columnName := range keys {
+		keyIndexMap[columnName] = idx
+	}
+
+	columns := make([]ColMapItem, 0, len(keys))
+	if len(records.Rows) > 0 {
+		for colIdx, column := range records.Rows[0].Columns {
+			if pkIdx, ok := keyIndexMap[column.ColumnName]; ok {
+				columns = append(columns, ColMapItem{pkIndex: pkIdx, colIndex: colIdx})
+			}
+		}
+		for i, row := range records.Rows {
+			if i > 0 {
+				lockKeys.WriteString(",")
+			}
+			primaryKeyValues := make([]interface{}, len(keys))
+			for _, mp := range columns {
+				if mp.colIndex < len(row.Columns) {
+					primaryKeyValues[mp.pkIndex] = row.Columns[mp.colIndex].Value
+				}
+			}
+			for j, pkVal := range primaryKeyValues {
+				if j > 0 {
+					lockKeys.WriteString("_")
+				}
+				if pkVal == nil {
+					continue
+				}
+				lockKeys.WriteString(fmt.Sprintf("%v", pkVal))
+			}
+		}
+	}
+	return lockKeys.String()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Modified two buildlockkeys    O (N×K) time complexity
**Which issue(s) this PR fixes**:  

baseExecutor ：buildLockkey ：O(N×M×K)-> O(N×K)；
BasicUndoLogBuilder ：buildLockkey2 ：O (N×M) -> O(N×K)；
increase readability, improve unit testing  

Fixes #829 
about :https://github.com/apache/incubator-seata-go/pull/714

```release-note

```